### PR TITLE
Remove line that hardcodes header to "under review"

### DIFF
--- a/tmlr.sty
+++ b/tmlr.sty
@@ -122,7 +122,6 @@
 %\linewidth\hsize \vskip 0.1in \toptitlebar \centering
 {\LARGE\bf\sffamily \@title\par}\vskip \aftertitskip
 %\bottomtitlebar % \vskip 0.1in %  minus
-\lhead{Under review as submission to TMLR}
 \if@accepted
     \if@preprint
         \@startauthor \@author \@endauthor


### PR DESCRIPTION
PR #3 added the options `preprint` and `accepted` that control anonymity and the header, but there was a stray additional line that overruled the header logic to always say "Under review as submission to TMLR".